### PR TITLE
ignore results of bundling with --binstubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,19 @@ config/site.rb
 config/database.yml
 config/overrides.yml
 config/recaptcha.yml
+
+# ignore results of bundling with --binstubs
+bin/autospec
+bin/htmldiff
+bin/ldiff
+bin/nokogiri
+bin/oauth
+bin/rackup
+bin/rake
+bin/rake2thor
+bin/restclient
+bin/rspec
+bin/thor
+bin/tilt
+bin/unicorn
+bin/unicorn_rails


### PR DESCRIPTION
Not sure if you'll want this for the main repository, but I use `--binstubs` with bundler and I have `./bin` in my path. 

That way I don't need to prefix everything with `bundle exec`.
