### PR TITLE
Make domain search string factory more permissive

### DIFF
--- a/lib/checkpoint/models/realm.rb
+++ b/lib/checkpoint/models/realm.rb
@@ -72,13 +72,18 @@ class Realm < ActiveRecord::Base
 
   private
 
-  # Provided a block, this method will yield variations on the host with increasing 
+  # Provided a block, this method will yield variations on the host with increasing
   # specificity: 'foo.bar.example.com' will yield "example.com", "bar.example.com",
   # "foo.bar.example.com".
   def self.search_strings_for_url(url, &block)
-    segments = url[/(?:https?\:\/\/)?([^\/]+)/,1].split('.') # extract the domain and split the subdomains
-    candidate = [segments.pop]
-    yield(candidate.unshift(segments.pop).join('.')) until segments.empty?
+    host = url[/(?:https?\:\/\/)?([^\/\:]+)/,1]
+    if host.include?('.')
+      segments = host.split('.')
+      candidate = [segments.pop]
+      yield(candidate.unshift(segments.pop).join('.')) until segments.empty?
+    else
+      yield host
+    end
   end
 
 end

--- a/spec/lib/models/realm_spec.rb
+++ b/spec/lib/models/realm_spec.rb
@@ -117,6 +117,17 @@ describe Realm do
         variants.should eq(['example.org'])
       end
 
+      it "handles localhost or other 'bare word' domains" do
+        variants = []
+        Realm.send(:search_strings_for_url, 'http://localhost/some/page') { |variant| variants << variant }
+        variants.should eq(['localhost'])
+      end
+
+      it "handles urls that include port numbers" do
+        variants = []
+        Realm.send(:search_strings_for_url, 'example.com:9292/some/page') { |variant| variants << variant }
+        variants.should eq(['example.com'])
+      end
     end
   end
 end


### PR DESCRIPTION
- adds support for 'localhost' or other single word (internal) domains
  - adds support for urls with a port number
