### PR TITLE
Don't give god session to user. Fixes #37.

### DIFF
--- a/api/v1/sessions.rb
+++ b/api/v1/sessions.rb
@@ -43,17 +43,16 @@ class CheckpointV1 < Sinatra::Base
 
   post '/sessions' do
     identity = Identity.find_by_id(params[:identity_id])
+    if identity
+      check_god_credentials(identity.realm_id)
+      @current_session = new_session
+    end
     identity ||= current_identity
     halt 500, "Identity not found" unless identity
-    unless identity == current_identity
-      check_god_credentials(identity.realm_id)
-    end
 
     log_in(identity)
-    @current_session = new_session
     pg :session, :locals => {:session => current_session}
   end
-
 
   # @apidoc
   # Delete a session key.


### PR DESCRIPTION
We have an endpoint that allows a god user to create a new session for a
user. This should return the newly created session.

Instead of doing this, the endpoint simply reassigned the god session to
the user.

This caused two problems:
- the god session could no longer be used as a god session, thus
  breaking scripts that rely on this session
- the user session didn't get a new session, it had a previously
  existing (god) session, though this session is no longer a god
  session.
