### PR TITLE
Update rack/sinatra + cleanup Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,6 @@ gem 'sinatra'
 gem 'sinatra-activerecord'
 gem 'rack-contrib'
 
-# Because of a bug in rack-protection (https://github.com/rkh/rack-protection/commit/a91810fa) that affects
-# cors-requests we'll need to get rack-protection from github
-# This can safely be changed to the official rubygems version '> 1.2.0' whenever it is released
-gem 'rack-protection', :git => 'git://github.com/rkh/rack-protection.git'
-
 gem 'activerecord', :require => 'active_record'
 gem 'activesupport'
 gem 'pg'
@@ -30,7 +25,6 @@ gem 'thor'
 gem 'unicorn', '~> 4.1.1'
 gem 'petroglyph'
 gem 'rake'
-gem 'rack', '~> 1.4', :git => 'git://github.com/rack/rack.git'
 gem 'queryparams'
 gem 'bengler_test_helper', :git => 'git://github.com/bengler/bengler_test_helper.git', :require => false
 gem 'simpleidn', '~> 0.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,19 +57,6 @@ GIT
       oauth
       omniauth (~> 1.0)
 
-GIT
-  remote: git://github.com/rack/rack.git
-  revision: 42b11a7fb918127143ca570af9930b2e7ef7222c
-  specs:
-    rack (1.5.1)
-
-GIT
-  remote: git://github.com/rkh/rack-protection.git
-  revision: 4a771b640d70dc1acc54b93e654537a5efec0491
-  specs:
-    rack-protection (1.2.0)
-      rack
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -148,8 +135,11 @@ GEM
       tilt
     pg (0.13.2)
     queryparams (0.0.3)
+    rack (1.5.2)
     rack-contrib (1.1.0)
       rack (>= 0.9.1)
+    rack-protection (1.3.2)
+      rack
     rack-test (0.6.1)
       rack (>= 1.0)
     raindrops (0.8.0)
@@ -169,9 +159,9 @@ GEM
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
     simpleidn (0.0.4)
-    sinatra (1.3.2)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
+    sinatra (1.3.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     sinatra-activerecord (0.1.3)
       sinatra (>= 0.9.4)
@@ -216,9 +206,7 @@ DEPENDENCIES
   petroglyph
   pg
   queryparams
-  rack (~> 1.4)!
   rack-contrib
-  rack-protection!
   rack-test
   rake
   rest-client


### PR DESCRIPTION
I've upgraded sinatra + rack (https://twitter.com/sinatra/status/299774391523360768). @simen, @alexstaubo: do you know why we used rack from github? I removed rack from Gemfile completely as its already depended on by sinatra. All tests still pass, so this should be safe to merge. Just wanted to double check with you.
