### PR TITLE
Write display param to session and pass it to facebook

### DIFF
--- a/api/v1/auth.rb
+++ b/api/v1/auth.rb
@@ -106,6 +106,7 @@ class CheckpointV1 < Sinatra::Base
     target_url.scheme ||= request.scheme
 
     session[:force_dialog] = params[:force_dialog].to_s == 'true'
+    session[:display] = params[:display]
 
     if on_primary_domain?
       session[:redirect_to] = target_url.to_s
@@ -128,6 +129,7 @@ class CheckpointV1 < Sinatra::Base
     service_keys = current_realm.keys_for(params[:provider].to_sym)
 
     strategy.options[:force_dialog] = session[:force_dialog]
+    strategy.options[:display] = session[:display] if params[:provider] == 'facebook'
     strategy.options[:target_url] = session[:redirect_to]
 
     if strategy.options.respond_to?(:consumer_key)
@@ -140,10 +142,6 @@ class CheckpointV1 < Sinatra::Base
       halt 500, "Invalid strategy for provider: #{params[:provider]}"
     end
     strategy.options[:scope] = service_keys.scope if service_keys.scope
-
-    # TODO: Add detection of device to wisely choose whether we should ask for
-    # touch interface from facebook.
-    # strategy.options[:display] = "touch" if params[:provider] == "facebook"
   end
 
   get '/auth/:provider/callback' do

--- a/spec/api/v1/auth_spec.rb
+++ b/spec/api/v1/auth_spec.rb
@@ -52,6 +52,11 @@ describe "Authorizations" do
       decode_cookie(rack_mock_session.cookie_jar['checkpoint.cookie'])['redirect_to'].should eq('http://example.org/somewhere/else')
     end
 
+    it "(optionally) passes the display param" do
+      get '/login/facebook', :display => 'popup'
+      decode_cookie(rack_mock_session.cookie_jar['checkpoint.cookie'])['display'].should eq('popup')
+    end
+
     it "configures strategy and redirects to twitter" do
       keys = valid_realm.keys_for(:twitter)
       VCR.use_cassette("twitter_auth_setup") do


### PR DESCRIPTION
This will allow clients to pass a `display=page|popup|touch` parameter to the `/login/facebook` route
