### PR TITLE
Fixed missing task name in bundle command to create realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Checkpoint is a centralized authentication broker for web applications that supp
 
 To initiate authentication, you first need to have a realm with a domain set up for your application:
 
-    $ bundle exec ./bin/checkpoint create example -t "Example Security Realm" -d example.org
+    $ bundle exec ./bin/checkpoint realm create example -t "Example Security Realm" -d example.org
 
 Checkpoint is provided as an http service and needs to be mapped into the url-space of your application using some proxy mechanism. The standard root url for checkpoint is:
 


### PR DESCRIPTION
When I run the command from README.md I get this error: 

vagrant@precise64:/vagrant/src/checkpoint$ bundle exec ./bin/checkpoint create example -t "Example Security Realm" -d 192.168.33.10
WARNING: Nokogiri was built against LibXML version 2.8.0, but has dynamically loaded 2.7.8
Could not find task "create".

When I add "realm" it seems to work. This pull request is about fixing the documentation.
