### PR TITLE
Facebook Graph 2.0 login + better strategy error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails-observers', '~> 0.1', require: false
 gem 'pg', '~> 0.17'
 gem 'omniauth', '~> 1.1.4'
 gem 'omniauth-twitter', :git => 'git://github.com/arunagw/omniauth-twitter.git'
-gem 'omniauth-facebook', '~> 1.4.1'
+gem 'omniauth-facebook', '~> 1.6'
 gem 'omniauth-contrib', '~> 1.0.0', :git => 'git://github.com/intridea/omniauth-contrib.git'
 gem 'omniauth-oauth', '~> 1.0.1', :git => 'git://github.com/intridea/omniauth-oauth.git'
 gem 'omniauth-oauth2', '~> 1.1.0', :git => 'git://github.com/intridea/omniauth-oauth2.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,8 +139,8 @@ GEM
       evernote-thrift
       multi_json (~> 1.0)
       omniauth-oauth (~> 1.0)
-    omniauth-facebook (1.4.1)
-      omniauth-oauth2 (~> 1.1.0)
+    omniauth-facebook (1.6.0)
+      omniauth-oauth2 (~> 1.1)
     omniauth-google-oauth2 (0.1.19)
       omniauth (~> 1.0)
       omniauth-oauth2
@@ -231,7 +231,7 @@ DEPENDENCIES
   omniauth (~> 1.1.4)
   omniauth-contrib (~> 1.0.0)!
   omniauth-evernote
-  omniauth-facebook (~> 1.4.1)
+  omniauth-facebook (~> 1.6)
   omniauth-google-oauth2 (~> 0.1.10)
   omniauth-oauth (~> 1.0.1)!
   omniauth-oauth2 (~> 1.1.0)!

--- a/api/v1/auth.rb
+++ b/api/v1/auth.rb
@@ -195,7 +195,7 @@ class CheckpointV1 < Sinatra::Base
   end
 
   get '/auth/failure' do
-    redirect url_for_failure(:message => params[:message] || 'unknown')
+    redirect url_for_failure(:message => params[:message] || 'unknown', :error => params[:error])
   end
 
   # FIXME: Should not offer this as GET.

--- a/api/v1/auth.rb
+++ b/api/v1/auth.rb
@@ -195,7 +195,8 @@ class CheckpointV1 < Sinatra::Base
   end
 
   get '/auth/failure' do
-    redirect url_for_failure(:message => params[:message] || 'unknown', :error => params[:error])
+    params[:message] ||= 'unknown'
+    redirect url_for_failure(params)
   end
 
   # FIXME: Should not offer this as GET.

--- a/api/v1/auth.rb
+++ b/api/v1/auth.rb
@@ -143,7 +143,14 @@ class CheckpointV1 < Sinatra::Base
     service_keys = current_realm.keys_for(params[:provider].to_sym)
 
     strategy.options[:force_dialog] = session[:force_dialog]
-    strategy.options[:display] = session[:display] if params[:provider] == 'facebook'
+    if params[:provider] ==  'facebook'
+      strategy.options[:display] = session[:display]
+      strategy.options[:client_options] ||= {}
+      strategy.options[:client_options] = strategy.options[:client_options].merge({
+        :site => 'https://graph.facebook.com/v2.0',
+        :authorize_url => "https://www.facebook.com/v2.0/dialog/oauth"
+      })
+    end
     strategy.options[:target_url] = session[:redirect_to]
 
     if strategy.options.respond_to?(:consumer_key)


### PR DESCRIPTION
Use Facebook login with Graph 2.0 (v1 stops working in april 2015). Friends list no longer included in the default scope.

Also pass through any strategy callback errors to /login/failure in order to have better error debugging and handling with provider auths than Omniauth can provide on its own.