### PR TITLE
Never return identities from other realms

### DIFF
--- a/spec/api/v1/sessions_spec.rb
+++ b/spec/api/v1/sessions_spec.rb
@@ -10,7 +10,9 @@ describe "Sessions" do
   end
 
   let :realm do
-    Realm.create!(:label => "area51")
+    realm = Realm.create!(:label => "area51")
+    Domain.create!(:realm => realm, :name => 'example.org')
+    realm
   end
 
   let :root_realm do


### PR DESCRIPTION
This adds an additional check in `GET /identities/:id` that the identity of the requested id belongs to the current realm.