### PR TITLE
Fix realm issues

### DIFF
--- a/api/v1.rb
+++ b/api/v1.rb
@@ -7,8 +7,6 @@ Dir.glob("#{File.dirname(__FILE__)}/v1/**/*.rb").each{ |file| require file }
 
 class CheckpointV1 < Sinatra::Base
 
-  class ConfigurationError < StandardError; end
-
   set :root, "#{File.dirname(__FILE__)}/v1"
   set :protection, :except => :http_origin
 

--- a/api/v1/identities.rb
+++ b/api/v1/identities.rb
@@ -107,34 +107,21 @@ class CheckpointV1 < Sinatra::Base
   # @status 200 [JSON]
 
   get '/identities/:id' do |id|
-    warn_no_realm_for_domain unless current_realm
     if id =~ /\,/
       # Retrieve a list of identities
       ids = id.split(/\s*,\s*/).compact
       identities = Identity.cached_find_all_by_id(ids).map do |identity|
         next nil if identity.nil?
-        warn_cross_realm_identity_req(identity) if current_realm && identity.realm.id != current_realm.id
-        identity
+        next identity if identity.realm.id == current_realm.id
       end
       pg :identities, :locals => {:identities => identities}
     else
       # Retrieve a single identity.
       identity = (id == 'me') ? current_identity : Identity.cached_find_by_id(id)
-
-      if identity.nil?
+      if identity.nil? or identity.realm.id != current_realm.id
         halt 200, {'Content-Type' => 'application/json'}, "{}"
       end
-      warn_cross_realm_identity_req(identity) if current_realm && identity.realm.id != current_realm.id
       pg :identity, :locals => {:identity => identity}
     end
-  end
-
-  private
-  def warn_cross_realm_identity_req(identity)
-    LOGGER.warn("cross-realm-identity-request: Domain of #{request.url} is not in realm (#{identity.realm.label}) of requested identity (#{identity.id}). Referrer: #{request.referrer}")
-  end
-
-  def warn_no_realm_for_domain
-    LOGGER.warn("cross-realm-identity-request: No realm for domain of #{request.url}")
   end
 end

--- a/spec/api/v1/access_groups_spec.rb
+++ b/spec/api/v1/access_groups_spec.rb
@@ -110,6 +110,7 @@ describe "Identities" do
     end
 
     it "will not create a group for non-gods" do
+      realm
       post "/access_groups"
       last_response.status.should eq 403
       post "/access_groups", :session => me_session
@@ -143,6 +144,7 @@ describe "Identities" do
     end
 
     it "will not create a group for non-gods" do
+      realm
       post "/access_groups"
       last_response.status.should eq 403
       post "/access_groups", :session => me_session
@@ -164,7 +166,8 @@ describe "Identities" do
     end
 
     it "will not retrieve groups from other realms" do
-      group = AccessGroup.create!(:realm => other_realm, :label => "the_consortium")
+      realm
+      AccessGroup.create!(:realm => other_realm, :label => "the_consortium")
       get "/access_groups/the_consortium"
       last_response.status.should eq 404
     end
@@ -295,6 +298,7 @@ describe "Identities" do
     end
 
     it "will only respond for groups in this realm" do
+      realm
       get "/access_groups/#{other_group.id}/memberships"
       last_response.status.should eq 404
     end
@@ -331,6 +335,7 @@ describe "Identities" do
     end
 
     it "doesn't grant access to unknown persons" do
+      realm
       get "/identities/1/access_to/abc.a.b.c"
       json_output['access']['granted'].should == false
     end

--- a/spec/api/v1/accounts_spec.rb
+++ b/spec/api/v1/accounts_spec.rb
@@ -14,7 +14,7 @@ describe "Accounts" do
   end
 
   let! :domain do
-    Domain.create!(:name => 'example.com', :realm => realm)
+    Domain.create!(:name => 'example.org', :realm => realm)
   end
 
   let! :identity do 

--- a/spec/api/v1/auth_spec.rb
+++ b/spec/api/v1/auth_spec.rb
@@ -31,7 +31,7 @@ describe "Authorizations" do
     realm
   }
 
-  it "returns a 400 (bad request) when the realm is nonexistant" do
+  it "returns a 412 (precondition failed) when the realm is nonexistant" do
     test_realm = Realm.create!(:label => 'the_404_test_realm', :service_keys => {})
     Domain.create!(:realm => test_realm, :name => 'www.unknown.com')
     get "/login/twitter"

--- a/spec/api/v1/auth_spec.rb
+++ b/spec/api/v1/auth_spec.rb
@@ -31,7 +31,7 @@ describe "Authorizations" do
     realm
   }
 
-  it "returns a 412 (precondition failed) when the realm is nonexistant" do
+  it "returns a 412 (precondition failed) when the realm is nonexistent" do
     test_realm = Realm.create!(:label => 'the_404_test_realm', :service_keys => {})
     Domain.create!(:realm => test_realm, :name => 'www.unknown.com')
     get "/login/twitter"

--- a/spec/api/v1/realms_spec.rb
+++ b/spec/api/v1/realms_spec.rb
@@ -41,7 +41,7 @@ describe "Realms" do
 
   it "lists the realms" do
     Realm.create!(:label => 'hell')
-    Realm.create!(:label => 'area51')
+    realm
     get "/realms"
     result = JSON.parse(last_response.body)
     result['realms'].sort.should eq ['hell', 'area51'].sort
@@ -87,7 +87,7 @@ describe "Realms" do
 
   it "can tell me which realm I'm on" do
     get "/realms/current"
-    JSON.parse(last_response.body)['realm'].should eq nil
+    last_response.status.should eq 412
     realm = Realm.create!(:label => 'area51')
     Domain.create!(:name => 'example.org', :realm => realm)
     get "/realms/current"

--- a/spec/api/v1/transfer_spec.rb
+++ b/spec/api/v1/transfer_spec.rb
@@ -58,6 +58,7 @@ describe "Transfers" do
 
   describe 'GET /transfer' do
     it 'rejects a request to transfer to an unregistered domain' do
+      origin_domain
       get "/transfer", :target => "http://wired.com/bananas"
       last_response.status.should eq 403
     end


### PR DESCRIPTION
This fixes two issues:
- 1) A request to checkpoint at a domain with no associated realm will now return a `412 (Precondition failed)`, e.g.: 
```
$ curl -I http://this.domain.is.valid.but.has.no.realm/api/checkpoint/v1/identities/me
HTTP/1.1 412 Precondition Failed
No realm is associated with the domain 'this.domain.is.valid.but.has.no.realm'
```
- 2) A request for an identity id that is in another realm than the realm associated with the request host will not be returned. Instead `/identities/me` will return `{}` as if the identity doesn't exists at all.